### PR TITLE
Prevent address bar spoofing and add 'Close tab' key binding option

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -1207,6 +1207,11 @@ iBool handleCommand_App(const char *cmd) {
         else {
             urlEncodePath_String(url);
         }
+       
+        /* Prevent address bar spoofing (mentioned as IDN homograph attack
+        in issue 73) */
+        punyEncodeUrlHost_String(url);
+       
         setUrlFromCache_DocumentWidget(doc, url, isHistory);
         /* Optionally, jump to a text in the document. This will only work if the document
            is already available, e.g., it's from "about:" or restored from cache. */

--- a/src/ui/keys.c
+++ b/src/ui/keys.c
@@ -85,6 +85,7 @@ static const struct { int id; iMenuItem bind; int flags; } defaultBindings_[] = 
     { 72, { "Reset zoom",                SDLK_0, KMOD_PRIMARY,          "zoom.set arg:100"   }, 0 },
     { 80, { "Previous tab",              prevTab_KeyShortcut,           "tabs.prev"          }, 0 },
     { 81, { "Next tab",                  nextTab_KeyShortcut,           "tabs.next"          }, 0 },
+    { 82, { "Close tab",                 'c', 0,                        "tabs.close"         }, 0 },
     { 100,{ "Toggle show URL on hover",  '/', KMOD_PRIMARY,             "prefs.hoverlink.toggle" }, 0 },
     /* The following cannot currently be changed (built-in duplicates). */
     { 1000, { NULL, SDLK_SPACE, KMOD_SHIFT, "scroll.page arg:-1" }, argRepeat_BindFlag },


### PR DESCRIPTION
Prevent IDN homograph attack in address bar and add 'Close tab' key binding option