### PR TITLE
Add private browsing mode

### DIFF
--- a/src/prefs.c
+++ b/src/prefs.c
@@ -33,6 +33,7 @@ void init_Prefs(iPrefs *d) {
     d->hoverLink         = iTrue;
     d->smoothScrolling   = iTrue;
     d->loadImageInsteadOfScrolling = iFalse;
+    d->privateMode       = iTrue;
     d->decodeUserVisibleURLs = iTrue;
     d->maxCacheSize      = 10;
     d->font              = nunito_TextFont;

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -47,6 +47,7 @@ struct Impl_Prefs {
     iBool            hoverLink;
     iBool            smoothScrolling;
     iBool            loadImageInsteadOfScrolling;
+    iBool            privateMode;
     /* Network */
     iBool            decodeUserVisibleURLs;
     int              maxCacheSize; /* MB */

--- a/src/ui/util.c
+++ b/src/ui/util.c
@@ -1064,6 +1064,8 @@ iWidget *makePreferences_Widget(void) {
         addChild_Widget(values, iClob(makeToggle_Widget("prefs.smoothscroll")));
         addChild_Widget(headings, iClob(makeHeading_Widget("Load image on scroll:")));
         addChild_Widget(values, iClob(makeToggle_Widget("prefs.imageloadscroll")));
+        addChild_Widget(headings, iClob(makeHeading_Widget("Private browsing:")));
+        addChild_Widget(values, iClob(makeToggle_Widget("prefs.privateMode")));
     }
     /* Window. */ {
         appendTwoColumnPage_(tabs, "Window", '2', &headings, &values);


### PR DESCRIPTION
I have made some code for adding private browsing mode to Lagrange in response to issue #60.

I think private browsing should be enabled by default for security and privacy. Obviously, a Gemini user will likely see the option in the preferences and enable it but it makes security easier to gain.

The disadvantage to this code is that a user cannot clear their already saved history without disabling private browsing. I might fix this in the future.

Sorry about the multiple pull requests. I'm still a beginner with Github so it can be a bit difficult.