### PR TITLE
Add Gemini link to home page

### DIFF
--- a/res/about/lagrange.gmi
+++ b/res/about/lagrange.gmi
@@ -13,3 +13,5 @@ o888ooooood8 `Y888""8o `8oooooo.  d888b    `Y888""8o o888o o888o `8oooooo.  `Y8b
 ## Version ${APP_VERSION}
 => https://skyjake.fi/@jk by @jk@skyjake.fi
 Powered by SDL 2, OpenSSL, and ☕️
+
+=> gemini://gemini.circumlunar.space/ Don't know where to start? Click here!


### PR DESCRIPTION
The home page of Lagrange contains no links to anything on Gemini. The only link is to your personal website, which is an HTTP website.

I think that for this reason the Gemini project link should be on the home page.