### PR TITLE
app: Open command line links in new tabs

### DIFF
--- a/src/app.c
+++ b/src/app.c
@@ -566,7 +566,6 @@ static void init_App_(iApp *d, int argc, char **argv) {
             terminate_App_(0);
         }
         /* Check for URLs. */
-        iBool newTab = iFalse;
         iConstForEach(CommandLine, i, &d->args) {
             const iRangecc arg = i.entry;
             if (i.argType == value_CommandLineArgType) {
@@ -581,9 +580,8 @@ static void init_App_(iApp *d, int argc, char **argv) {
                                       : makeFileUrl_String(collectNewRange_String(arg));
                     pushBack_StringList(openCmds,
                                         collectNewFormat_String(
-                                            "open newtab:%d url:%s", newTab, cstr_String(decUrl)));
+                                            "open newtab:1 url:%s", cstr_String(decUrl)));
                     delete_String(decUrl);
-                    newTab = iTrue;
                 }
                 else {
                     fprintf(stderr, "Invalid URL/file: %s\n", cstr_Rangecc(arg));


### PR DESCRIPTION
Replacing the existing tab is unexpected and probably undesired. Now
matches Firefox's command line behaviour. (together with the fix in #234 )

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>