### PR TITLE
Update macOS install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ Like Gemini, Lagrange has been designed with minimalism in mind. It depends on a
 
 Prebuilt binaries for Windows, macOS and Linux can be found in [Releases][rel]. You can also find [Lagrange on Flathub for Linux](https://flathub.org/apps/details/fi.skyjake.Lagrange).
 
-On macOS you can install and upgrade via a Homebrew tap:
+On macOS you can install and upgrade via a Homebrew:
 
 ```
-$ brew tap skyjake/lagrange
-$ brew install lagrange
+brew install --cask lagrange
 ```
 
 On openSUSE Tumbleweed:


### PR DESCRIPTION
Lagrange has been added to official Homebrew Cask tap (https://github.com/Homebrew/homebrew-cask/pull/107506).