### PR TITLE
Lagrange build failed, due to missing base. in ui/window.c

### DIFF
--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -530,10 +530,10 @@ void init_MainWindow(iMainWindow *d, iRect rect) {
     useExecutableIconResource_SDLWindow(d->base.win);
 #endif
 #if defined (iPlatformLinux)
-    SDL_SetWindowMinimumSize(d->win, minSize.x * d->base.pixelRatio, minSize.y * d->base.pixelRatio);
+    SDL_SetWindowMinimumSize(d->base.win, minSize.x * d->base.pixelRatio, minSize.y * d->base.pixelRatio);
     /* Load the window icon. */ {
         SDL_Surface *surf = loadImage_(&imageLagrange64_Embedded, 0);
-        SDL_SetWindowIcon(d->win, surf);
+        SDL_SetWindowIcon(d->base.win, surf);
         free(surf->pixels);
         SDL_FreeSurface(surf);
     }


### PR DESCRIPTION
With a fresh clone of the repo the build of lagrange failed with the information, that there is no member 'win' in d at src/ui/window.c 533 and 536. d->base.win however exists.