### PR TITLE
Add guppy:// support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ set (SOURCES
     src/gmutil.h
     src/gopher.c
     src/gopher.h
+    src/guppy.c
+    src/guppy.h
     src/history.c
     src/history.h
     src/lang.c

--- a/src/app.c
+++ b/src/app.c
@@ -1089,7 +1089,7 @@ static void communicateWithRunningInstance_App_(iApp *d, iProcessId instance,
 
 static iBool hasCommandLineOpenableScheme_(const iRangecc uri) {
     static const char *schemes[] = {
-        "gemini:", "gopher:", "finger:", "spartan:", "nex:", "file:", "data:", "about:"
+        "gemini:", "gopher:", "finger:", "spartan:", "nex:", "guppy:", "file:", "data:", "about:"
     };
     iForIndices(i, schemes) {
         if (startsWithCase_Rangecc(uri, schemes[i])) {

--- a/src/defs.h
+++ b/src/defs.h
@@ -286,6 +286,7 @@ iLocalDef int acceptKeyMod_ReturnKeyBehavior(int behavior) {
 #define toggleNo_Icon       bullet_Icon
 #define spartan_Icon        "\U0001f4aa"
 #define nex_Icon            "\U0001f687"
+#define guppy_Icon          "\U0001f41f"
 #define keyboard_Icon       "\u2328"
 #define network_Icon        "\U0001f5a7"
 #define computer_Icon       "\U0001f5b3"

--- a/src/gmdocument.c
+++ b/src/gmdocument.c
@@ -415,6 +415,9 @@ static iRangecc addLink_GmDocument_(iGmDocument *d, iRangecc line, iGmLinkId *li
             else if (equalCase_Rangecc(parts.scheme, "nex")) {
                 setScheme_GmLink_(link, nex_GmLinkScheme);
             }
+            else if (equalCase_Rangecc(parts.scheme, "guppy")) {
+                setScheme_GmLink_(link, guppy_GmLinkScheme);
+            }
             else if (equalCase_Rangecc(parts.scheme, "file")) {
                 setScheme_GmLink_(link, file_GmLinkScheme);
             }
@@ -1050,6 +1053,7 @@ static void doLayout_GmDocument_(iGmDocument *d) {
                                              : scheme == titan_GmLinkScheme    ? uploadArrow
                                              : scheme == finger_GmLinkScheme   ? pointingFinger
                                              : scheme == nex_GmLinkScheme      ? nex_Icon
+                                             : scheme == guppy_GmLinkScheme    ? guppy_Icon
                                              : (scheme == spartan_GmLinkScheme && !d->flags.isSpartan)
                                                                                ? spartan_Icon
                                              : scheme == mailto_GmLinkScheme   ? envelope

--- a/src/gmdocument.h
+++ b/src/gmdocument.h
@@ -81,6 +81,7 @@ enum iGmLinkScheme {
     mailto_GmLinkScheme,
     spartan_GmLinkScheme,
     nex_GmLinkScheme,
+    guppy_GmLinkScheme,
 };
 
 enum iGmLinkFlag {

--- a/src/gmutil.c
+++ b/src/gmutil.c
@@ -110,6 +110,9 @@ uint16_t port_Url(const iUrl *d) {
     else if (equalCase_Rangecc(d->scheme, "spartan")) {
         port = 300;
     }
+    else if (equalCase_Rangecc(d->scheme, "guppy")) {
+        port = 6775;
+    }
     else if (equalCase_Rangecc(d->scheme, "https")) {
         port = 443;
     }

--- a/src/guppy.c
+++ b/src/guppy.c
@@ -1,0 +1,236 @@
+/* Copyright 2023 Dima Krasner <dima@dimakrasner.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+#include "guppy.h"
+
+#include <the_Foundation/regexp.h>
+
+#include <SDL_timer.h>
+
+iDefineAudienceGetter(Guppy, timeout)
+iDeclareNotifyFunc(Guppy, Timeout)
+
+void init_Guppy(iGuppy *d) {
+    d->state = none_GuppyState;
+    d->mtx = NULL;
+    d->url = NULL;
+    d->socket = NULL;
+    d->body = NULL;
+    d->timer = 0;
+    d->firstSent = 0;
+    d->lastSent = 0;
+    for (size_t i = 0; i < sizeof(d->chunks) / sizeof(d->chunks[0]); ++i) {
+        d->chunks[i].seq = 0;
+        init_Block(&d->chunks[i].data, 0);
+    }
+    d->firstSeq = 0;
+    d->lastSeq = 0;
+    d->currentSeq = 0;
+    d->timeout = NULL;
+}
+
+void deinit_Guppy(iGuppy *d) {
+    if (d->timer) {
+        SDL_RemoveTimer(d->timer);
+    }
+    for (size_t i = 0; i < sizeof(d->chunks) / sizeof(d->chunks[0]); ++i) {
+        deinit_Block(&d->chunks[i].data);
+    }
+    delete_Audience(d->timeout);
+}
+
+static void request_Guppy_(iGuppy *d) {
+    write_Socket(d->socket, utf8_String(collectNewFormat_String("%s\r\n", cstr_String(d->url))));
+}
+
+static void ack_Guppy_(iGuppy *d, const int seq) {
+    write_Socket(d->socket, utf8_String(collectNewFormat_String("%d\r\n", seq)));
+}
+
+static uint32_t retryGuppy_(uint32_t interval, iAny *ptr) {
+    iGuppy *d = (iGuppy *)ptr;
+    lock_Mutex(d->mtx);
+    uint64_t now = SDL_GetTicks64();
+    /* Stop the session on timeout */
+    if (now >= d->firstSent + 6000) {
+       unlock_Mutex(d->mtx);
+       iNotifyAudience(d, timeout, GuppyTimeout);
+       return 0;
+    /* Resend the request if we're still waiting for the first chunk */
+    } else if (!d->firstSeq && status_Socket(d->socket) == connected_SocketStatus && now >= d->lastSent + 1000) {
+        request_Guppy_(d);
+        d->lastSent = now;
+    /* Resend the last ack if we're still waiting for more chunks */
+    } else if (d->currentSeq && now >= d->lastSent + 500) {
+        ack_Guppy_(d, d->currentSeq);
+        d->lastSent = now;
+    }
+    unlock_Mutex(d->mtx);
+    return 100;
+}
+
+void open_Guppy(iGuppy *d) {
+    d->state = inProgress_GuppyState;
+    request_Guppy_(d);
+    d->lastSent = SDL_GetTicks64();
+    if (!d->firstSent) {
+        d->firstSent = d->lastSent;
+    }
+    if (!d->timer) {
+        d->timer = SDL_AddTimer(100, retryGuppy_, d);
+    }
+}
+
+void cancel_Guppy(iGuppy *d) {
+    SDL_RemoveTimer(d->timer);
+    d->timer = 0;
+}
+
+static void storeChunk_Guppy_(iGuppy *d, int seq, const void *data, size_t size) {
+    int slot = -1, maxSeq = -1, maxSeqSlot = -1;
+    bool found = false;
+    if (!d->firstSeq && seq < INT_MAX) {
+        d->firstSeq = seq;
+    }
+    if (!d->lastSeq && size == 0) {
+        d->lastSeq = seq;
+        return;
+    }
+    if ((d->currentSeq && seq <= d->currentSeq) || (d->firstSeq && seq < d->firstSeq) || (d->lastSeq && seq > d->lastSeq)) {
+        return;
+    }
+    for (size_t i = 0; i < sizeof(d->chunks) / sizeof(d->chunks[0]); ++i) {
+        /* Maybe we already have this chunk */
+        if ((found = (d->chunks[i].seq == seq))) {
+            break;
+        }
+        /* We found a slot we can use */
+        if (slot < 0 && (d->chunks[i].seq == 0 || (d->firstSeq > 0 && d->chunks[i].seq < d->firstSeq) || (d->lastSeq > 0 && d->chunks[i].seq > d->lastSeq))) {
+            slot = i;
+        }
+        /* This slot is the one we're less likely to need soon */
+        if (d->chunks[i].seq > maxSeq) {
+            maxSeq = d->chunks[i].seq;
+            maxSeqSlot = i;
+        }
+    }
+    if (!found) {
+        /* Must free one slot if this is the first chunk but all slots are occupied */
+        if (seq == d->firstSeq && slot < 0) {
+            slot = maxSeqSlot;
+        }
+        if (slot >= 0) {
+            d->chunks[slot].seq = seq;
+            setData_Block(&d->chunks[slot].data, data, size);
+        }
+    }
+}
+
+static void processChunks_Guppy_(iGuppy *d, iBool *notifyUpdate) {
+    iBool again = iFalse;
+    do {
+        /* Append consequentive chunks we have at the moment */
+        again = false;
+        for (size_t i = 0; i < sizeof(d->chunks) / sizeof(d->chunks[0]); ++i) {
+            if ((d->currentSeq && d->currentSeq < INT_MAX && d->chunks[i].seq == d->currentSeq + 1) || (d->currentSeq == 0 && d->firstSeq > 0 && d->chunks[i].seq == d->firstSeq)) {
+                append_Block(d->body, &d->chunks[i].data);
+                *notifyUpdate = iTrue;
+                d->currentSeq = d->chunks[i].seq;
+                d->chunks[i].seq = 0;
+                clear_Block(&d->chunks[i].data);
+                again = i < sizeof(d->chunks) / sizeof(d->chunks[0]) - 1;
+            }
+        }
+    } while (again);
+    /* We're done if the last chunk appended to the buffer is the one before the EOF packet */
+    if (d->lastSeq && d->currentSeq == d->lastSeq - 1) {
+        d->state = finished_GuppyState;
+    }
+}
+
+enum iGuppyState processResponse_Guppy(iGuppy *d, iBool *notifyUpdate) {
+    iBlock *data = readAll_Socket(d->socket);
+    if (!isEmpty_Block(data)) {
+        iString header;
+        init_String(&header);
+        append_Block(&header.chars, data);
+        size_t crlf = indexOfCStr_String(&header, "\r\n");
+        if (crlf != iInvalidPos) {
+            truncate_Block(&header.chars, crlf);
+            iRegExp *metaPattern = new_RegExp("^([0-9]+)(.*)", 0);
+            iRegExpMatch m;
+            init_RegExpMatch(&m);
+            iBool first = iFalse;
+            if (matchString_RegExp(metaPattern, &header, &m)) {
+                int seq = toInt_String(collect_String(captured_RegExpMatch(&m, 1)));
+                if (!d->firstSeq) {
+                    iString *meta = collect_String(captured_RegExpMatch(&m, 2));
+                    size_t metaLength = length_String(meta);
+                    if (metaLength > 0) {
+                        meta = collect_String(mid_String(meta, 1, metaLength - 1));
+                    }
+                    switch (seq) {
+                        case 0:
+                        case 5:
+                            d->state = invalidResponse_GuppyState;
+                            clear_String(meta);
+                            break;
+                        case 1:
+                            d->state = inputRequired_GuppyState;
+                            set_String(d->meta, meta);
+                            break;
+                        case 3:
+                            d->state = redirect_GuppyState;
+                            set_String(d->meta, meta);
+                            break;
+                        case 4:
+                            d->state = error_GuppyState;
+                            break;
+                        default:
+                            first = iTrue;
+                            d->state = inProgress_GuppyState;
+                            if (meta) {
+                                set_String(d->meta, meta);
+                            }
+                    }
+                }
+                if (seq >= 6) {
+                    ack_Guppy_(d, seq);
+                    d->lastSent = SDL_GetTicks64();
+                    if (d->state == inProgress_GuppyState) {
+                        storeChunk_Guppy_(d, seq, constData_Block(data) + crlf + 2, size_Block(data) - crlf - 2);
+                    }
+                }
+            } else {
+                d->state = invalidResponse_GuppyState;
+            }
+            iRelease(metaPattern);
+            processChunks_Guppy_(d, notifyUpdate);
+        }
+        deinit_String(&header);
+    }
+    delete_Block(data);
+    if (d->state != inProgress_GuppyState) {
+        cancel_Guppy(d);
+    }
+    return d->state;
+}

--- a/src/guppy.h
+++ b/src/guppy.h
@@ -1,0 +1,70 @@
+/* Copyright 2023 Dima Krasner <dima@dimakrasner.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+#pragma once
+
+#include <the_Foundation/mutex.h>
+#include <the_Foundation/string.h>
+#include <the_Foundation/socket.h>
+#include <the_Foundation/audience.h>
+
+enum iGuppyState {
+    none_GuppyState,
+    inProgress_GuppyState,
+    invalidResponse_GuppyState,
+    inputRequired_GuppyState,
+    redirect_GuppyState,
+    error_GuppyState,
+    finished_GuppyState
+};
+
+struct GuppyChunk {
+    int    seq;
+    iBlock data;
+};
+
+iDeclareType(Guppy)
+
+struct Impl_Guppy {
+    enum iGuppyState  state;
+    iMutex *          mtx;
+    iString *         url;
+    iString *         meta;
+    iSocket *         socket;
+    iBlock *          body;
+    int               timer;
+    uint64_t          firstSent;
+    uint64_t          lastSent;
+    struct GuppyChunk chunks[16];
+    int               firstSeq;
+    int               lastSeq;
+    int               currentSeq;
+    iAudience *       timeout;
+};
+
+iDeclareTypeConstruction(Guppy)
+
+iDeclareAudienceGetter(Guppy, timeout)
+
+void              open_Guppy                 (iGuppy *);
+void              cancel_Guppy               (iGuppy *);
+enum iGuppyState  processResponse_Guppy      (iGuppy *, iBool *notifyUpdate);


### PR DESCRIPTION
Protocol is described in gemini://gemini.dimakrasner.com/guppy-v0.4.gmi (or guppy://gemini.dimakrasner.com/guppy-v0.4.gmi). **EDIT:** moved to gemini://guppy.000090000.xyz, guppy://guppy.000090000.xyz and https://github.com/dimkr/guppy-protocol

I was thinking, if Lagrange supports Nex, maybe it would be nice to support Guppy too, especially if this doesn't complicate the implementation of other protocols and doesn't introduce stability or security risks for those who don't use this protocol at all. v0.4 of the protocol includes additions and changes (like status code 1) that increase code reuse if support for this protocol is added to an existing Gemini client. If this protocol takes off thanks to high quality implementations of clients and servers, great! If not, this is not the end of the world and I understand that a new protocol needs special treatment in the crowded space of gmrequest.c (especially if it's based on UDP and not TCP like the others) and every line of code can be a burden.

This PR implements Guppy v0.4 support with:
- 16 cached data chunks, appended to the rendered document in the correct order as early as possible
  - Enough to receive and render a 8K sized document sent in 512b chunks, without having to wait for some chunks to be re-transmitted (should be very generous considering average and median page size stats from Gemini crawlers)
  - With logic to free a cache slot if the first response chunk arrives after all slots are occupied by other chunks
- Retries (not very smart, every 100ms)
  - Retry of the request every 1s until the first response chunk is received
  - Retry of the last acknowledgement packet every 500ms, until more data is received
- Support for input prompts and redirects
- 🐟 for guppy:// links  

This implementation is naive in some ways, I can't rule out the possibility of memory leaks or corner cases I haven't fixed, and I can see places where the implementation can be optimized to reduce memory copying at the cost of extra code complexity.

Tested against guppy://hd.206267.xyz, server code is available at https://github.com/dimkr/tootik/compare/guppy and the protocol spec contains Python examples that might be easier to understand and scrutinize for corner cases that need to be handled in a reliable and well-behaving client.

For this to work, iSocket constructor needs to receive an additional socket type parameter:
 
```
diff --git a/include/the_Foundation/socket.h b/include/the_Foundation/socket.h
index 33e3821..3c6878b 100644
--- a/include/the_Foundation/socket.h
+++ b/include/the_Foundation/socket.h
@@ -73,7 +73,7 @@ enum iSocketStatus {
     disconnected_SocketStatus,
 };
 
-iDeclareObjectConstructionArgs(Socket, const char *hostName, uint16_t port)
+iDeclareObjectConstructionArgs(Socket, const char *hostName, uint16_t port, enum iSocketType socketType)
 
 iSocket *   newAddress_Socket   (const iAddress *address);
 iSocket *   newExisting_Socket  (int fd, const void *sockAddr, size_t sockAddrSize);
diff --git a/src/platform/posix/socket.c b/src/platform/posix/socket.c
index 047ce16..c9f1d9c 100644
--- a/src/platform/posix/socket.c
+++ b/src/platform/posix/socket.c
@@ -55,6 +55,7 @@ struct Impl_Socket {
     iBuffer *output;
     iBuffer *input;
     enum iSocketStatus status;
+    enum iSocketType type;
     iAddress *address;
     int fd;
     iPipe *stopConnect;
@@ -238,8 +239,8 @@ iLocalDef void start_SocketThread(iSocketThread *d) { start_Thread(&d->thread);
 /*-------------------------------------------------------------------------------------*/
 
 iDefineObjectConstructionArgs(Socket,
-                              (const char *hostName, uint16_t port),
-                              hostName, port)
+                              (const char *hostName, uint16_t port, enum iSocketType socketType),
+                              hostName, port, socketType)
 
 static iBool setStatus_Socket_(iSocket *d, enum iSocketStatus status) {
     if (d->status != status) {
@@ -258,6 +259,7 @@ static void init_Socket_(iSocket *d) {
     openEmpty_Buffer(d->output);
     openEmpty_Buffer(d->input);
     d->fd = -1;
+    d->type = tcp_SocketType;
     d->address = NULL;
     d->stopConnect = new_Pipe(); /* used for aborting select() on user action */
     d->connecting = NULL;
@@ -511,12 +513,12 @@ iSocket *newExisting_Socket(int fd, const void *sockAddr, size_t sockAddrSize) {
     return d;
 }
 
-void init_Socket(iSocket *d, const char *hostName, uint16_t port) {
+void init_Socket(iSocket *d, const char *hostName, uint16_t port, enum iSocketType socketType) {
     init_Socket_(d);
     d->address = new_Address();
     setStatus_Socket_(d, addressLookup_SocketStatus);
     iConnect(Address, d->address, lookupFinished, d, addressLookedUp_Socket_);
-    lookupTcpCStr_Address(d->address, hostName, port);
+    lookupCStr_Address(d->address, hostName, port, socketType);
 }
 
 iBool open_Socket(iSocket *d) {
diff --git a/src/platform/win32/socket.c b/src/platform/win32/socket.c
index 2ebf680..e879329 100644
--- a/src/platform/win32/socket.c
+++ b/src/platform/win32/socket.c
@@ -237,8 +237,8 @@ iLocalDef void start_SocketThread(iSocketThread *d) { start_Thread(&d->thread);
 /*-------------------------------------------------------------------------------------*/
 
 iDefineObjectConstructionArgs(Socket,
-                              (const char *hostName, uint16_t port),
-                              hostName, port)
+                              (const char *hostName, uint16_t port, enum iSocketType socketType)),
+                              hostName, port, socketType)
 
 static iBool setStatus_Socket_(iSocket *d, enum iSocketStatus status) {
     if (d->status != status) {
@@ -498,12 +498,12 @@ iSocket *newExisting_Socket(int fd, const void *sockAddr, size_t sockAddrSize) {
     return d;
 }
 
-void init_Socket(iSocket *d, const char *hostName, uint16_t port) {
+void init_Socket(iSocket *d, const char *hostName, uint16_t port, enum iSocketType socketType) {
     init_Socket_(d);
     d->address = new_Address();
     setStatus_Socket_(d, addressLookup_SocketStatus);
     iConnect(Address, d->address, lookupFinished, d, addressLookedUp_Socket_);
-    lookupTcpCStr_Address(d->address, hostName, port);
+    lookupCStr_Address(d->address, hostName, port, socketType);
 }
 
 iBool open_Socket(iSocket *d) {
diff --git a/src/tlsrequest.c b/src/tlsrequest.c
index 1e03493..31cc55e 100644
--- a/src/tlsrequest.c
+++ b/src/tlsrequest.c
@@ -1117,7 +1117,7 @@ void submit_TlsRequest(iTlsRequest *d) {
     if (d->sessionCacheEnabled) {
         d->cert = maybeReuseSession_Context_(context_, d->ssl, d->hostName, d->port, d->clientCert);
     }
-    d->socket = new_Socket(cstr_String(d->hostName), d->port);
+    d->socket = new_Socket(cstr_String(d->hostName), d->port, tcp_SocketType);
     iConnect(Socket, d->socket, connected, d, connected_TlsRequest_);
     iConnect(Socket, d->socket, disconnected, d, disconnected_TlsRequest_);
     iConnect(Socket, d->socket, readyRead, d, gotIncoming_TlsRequest_);
```
(plus something similar for win32)