### PR TITLE
Add GenericName to desktop entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,6 +599,7 @@ elseif (UNIX AND NOT APPLE)
     set (desktop ${CMAKE_CURRENT_BINARY_DIR}/fi.skyjake.Lagrange.desktop)
     file (WRITE ${desktop} "[Desktop Entry]
 Name=Lagrange
+GenericName=Gemini Client
 Comment=${PROJECT_DESCRIPTION}
 Categories=Network;
 Exec=${CMAKE_INSTALL_PREFIX}/bin/lagrange %U


### PR DESCRIPTION
Thank you for creating Lagrange - it makes browsing Gemini much more pleasant!

This is a simple change to the .desktop file on Linux. The "GenericName" field is a generic description of what the program does. Some launchers allow you to search by this, which is very useful for those of us that struggle to remember things - if I haven't gone on Gemini in a while and I forgot the name of Lagrange, I can just type "gemini" into my launcher, and Lagrange will come up.

Similar uses are in Emacs:

```
[Desktop Entry]
Name=Emacs
GenericName=Text Editor
```

Hexchat:

```
[Desktop Entry]
Name=HexChat
GenericName=IRC Client
```

Firefox:

```
[Desktop Entry]
Version=1.0
Name=Firefox Web Browser
GenericName=Web Browser
```

...and many other programs besides.