### PR TITLE
Possible #612 fix

### DIFF
--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1506,10 +1506,11 @@ iBool dispatchEvent_Window(iWindow *d, const SDL_Event *ev) {
                     continue;
                 }
             }
-            if (ev->type == SDL_MOUSEWHEEL && !contains_Rect(rect_Root(root),
-                                                             coord_MouseWheelEvent(&ev->wheel))) {
-                continue; /* Only process the event in the relevant split. */
-            }
+            // Commenting this out appears to resolve issue #612
+            //if (ev->type == SDL_MOUSEWHEEL && !contains_Rect(rect_Root(root),
+            //                                                 coord_MouseWheelEvent(&ev->wheel))) {
+            //    continue; /* Only process the event in the relevant split. */
+            //}
             if (!root->widget) {
                 continue;
             }


### PR DESCRIPTION
Issue #612 is about scrolling not working on secondary monitors when running under Wayland.

@tuomovee says that removing the check for the `mousewheel` event in `dispatchEvent_Window()` appears to resolve the issue, but is unaware of any potential consequences.

This does fix the issue on Wayland, with *seemingly* no consequences, split views appear to behave fine.
I haven't tested this on X11, but I can.

So barring anyone coming in and saying this is the worst idea ever, it looks like a fix?


