### PR TITLE
gemini responses: Fix unbounded header length

### DIFF
--- a/src/gmrequest.c
+++ b/src/gmrequest.c
@@ -267,6 +267,13 @@ static int processIncomingData_GmRequest_(iGmRequest *d, const iBlock *data) {
             checkServerCertificate_GmRequest_(d);
             iRelease(metaPattern);
         }
+        else if (size_String(&resp->meta) > 2048) {
+            /* The Gemini "tech overview" caps <META> at 1024 bytes; use 2048 for generosity */
+            clear_String(&resp->meta);
+            resp->statusCode = invalidHeader_GmStatusCode;
+            d->state         = finished_GmRequestState;
+            notifyDone       = iTrue;
+        }
     }
     else if (d->state == receivingBody_GmRequestState) {
         append_Block(&resp->body, data);


### PR DESCRIPTION
This could have led to a crash from resource exhaustion when pointed at a malicious or non-Gemini server which streamed a large amount of data with no CRLF in place of the normal response line.