### PR TITLE
fix #793 i guess

### DIFF
--- a/src/render/font.c
+++ b/src/render/font.c
@@ -55,44 +55,17 @@ int fontWithFamily_Text(int font, enum iFontId familyId) {
 
 iTextMetrics draw_WrapText(iWrapText *d, int fontId, iInt2 pos, int color) {
     iTextMetrics tm;
-#if !defined (LAGRANGE_ENABLE_HARFBUZZ)
-    /* In simple mode, each line must be wrapped first so we can break at the right points
-       and do wrap notifications before drawing. */
-    iRangecc text = d->text;
-    iZap(tm);
-    d->wrapRange_ = (iRangecc){ d->text.start, d->text.start };
-    const iInt2 orig = pos;
-    while (!isEmpty_Range(&text)) {
-        const char *endPos;
-        const int width = d->mode == word_WrapTextMode
-                              ? tryAdvance_Text(fontId, text, d->maxWidth, &endPos).x
-                              : tryAdvanceNoWrap_Text(fontId, text, d->maxWidth, &endPos).x;
-        if (endPos == text.start) {
-            break; /* too tight for even a single character */
-        }
-        notify_WrapText(d, endPos, (iTextAttrib){ .fgColorId = color }, 0, width);
-        drawRange_Text(fontId, pos, color, (iRangecc){ text.start, endPos });
-        text.start = endPos;
-        pos.y += lineHeight_Text(fontId);
-        tm.bounds.size.x = iMax(tm.bounds.size.x, width);
-        tm.bounds.size.y = pos.y - orig.y;
-    }
-    tm.advance = sub_I2(pos, orig);
-#else
     run_Font(font_Text(fontId),
-             &(iRunArgs){
-                 .mode = draw_RunMode | runFlags_FontId(fontId) |
-                         (color & permanent_ColorId ? permanentColorFlag_RunMode : 0) |
-                         (color & fillBackground_ColorId ? fillBackground_RunMode : 0),
-                 .text = d->text,
-                 .pos = pos,
-                 .wrap = d,
-                 .justify = d->justify,
-                 .layoutBound = d->justify ? d->maxWidth : 0,
-                 .color = color & mask_ColorId,
-                 .metrics_out = &tm,
-             });
-#endif
+             &(iRunArgs){ .mode = draw_RunMode | runFlags_FontId(fontId) |
+                                   (color & permanent_ColorId ? permanentColorFlag_RunMode : 0) |
+                                   (color & fillBackground_ColorId ? fillBackground_RunMode : 0),
+                           .text = d->text,
+                           .pos = pos,
+                           .wrap = d,
+                           .justify = d->justify,
+                           .layoutBound = d->justify ? d->maxWidth : 0,
+                           .color = color & mask_ColorId,
+                           .metrics_out = &tm });
     return tm;
 }
 

--- a/src/render/text.c
+++ b/src/render/text.c
@@ -270,21 +270,9 @@ void drawBoundRange_Text(int fontId, iInt2 pos, int boundWidth, iBool justify, i
 }
 
 int drawWrapRange_Text(int fontId, iInt2 pos, int maxWidth, int color, iRangecc text) {
-    /* TODO: Use WrapText here, too */
-    const char *endp;
-    while (!isEmpty_Range(&text)) {
-        iInt2 adv = tryAdvance_Text(fontId, text, maxWidth, &endp);
-        drawRange_Text(fontId, pos, color, (iRangecc){ text.start, endp });
-        if (text.start == endp) {
-            adv = tryAdvanceNoWrap_Text(fontId, text, maxWidth, &endp);
-            if (text.start == endp) {
-                break; /* let's not get stuck */
-            }
-        }
-        text.start = endp;
-        pos.y += iMax(adv.y, lineHeight_Text(fontId));
-    }
-    return pos.y;
+    iWrapText wrap = { .text = text, .maxWidth = maxWidth, .mode = word_WrapTextMode };
+    iTextMetrics tm = draw_WrapText(&wrap, fontId, pos, color);
+    return pos.y + tm.bounds.size.y;
 }
 
 void drawCentered_Text(int fontId, iRect rect, iBool alignVisual, int color, const char *format, ...) {

--- a/src/render/text_simple.c
+++ b/src/render/text_simple.c
@@ -68,6 +68,8 @@ static void runSimple_Font_(iFont *d, const iRunArgs *args) {
        being in a pre-composed form). This algorithm is used if HarfBuzz is not available. */
     const iInt2 orig        = args->pos;
     iTextAttrib attrib      = { .fgColorId = args->color };
+    iColor ansiFg = get_Color(args->color);
+    iBool hasAnsi = iFalse;
     iRect       bounds      = { orig, init_I2(0, d->font.height) };
     float       xpos        = orig.x;
     float       xposMax     = xpos;
@@ -99,7 +101,7 @@ static void runSimple_Font_(iFont *d, const iRunArgs *args) {
     }
     /* The default text foreground color. */
     if (mode & draw_RunMode) {
-        const iColor clr = get_Color(args->color);
+        const iColor clr = hasAnsi ? ansiFg : get_Color(args->color);
 #if defined (LAGRANGE_ENABLE_STB_TRUETYPE)
         SDL_SetTextureColorMod(cache, clr.r, clr.g, clr.b);
 #endif
@@ -113,7 +115,7 @@ static void runSimple_Font_(iFont *d, const iRunArgs *args) {
                 (mode & underline_RunMode ? SDL_TEXT_ATTRIBUTE_BOLD | SDL_TEXT_ATTRIBUTE_UNDERLINE : 0));
 #endif
         if (args->mode & fillBackground_RunMode) {
-            const iColor initial = get_Color(args->color);
+            const iColor initial = hasAnsi ? ansiFg : get_Color(args->color);
             SDL_SetRenderDrawColor(render, initial.r, initial.g, initial.b, 0);
 //#if defined (SDL_SEAL_CURSES)
 //            SDL_SetRenderTextFillColor(render, initial.r, initial.g, initial.b, 255);
@@ -141,24 +143,28 @@ static void runSimple_Font_(iFont *d, const iRunArgs *args) {
             iRegExpMatch m;
             init_RegExpMatch(&m);
             if (match_RegExp(current_Text()->ansiEscape, chPos, args->text.end - chPos, &m)) {
-                if (mode & draw_RunMode && ~mode & permanentColorFlag_RunMode) {
+                if (mode & (draw_RunMode | measure_RunMode) && ~mode & permanentColorFlag_RunMode) {
                     /* Change the color. */
-                    iColor clr = get_Color(args->color);
+                    iColor parsedColor;
                     ansiColors_Color(capturedRange_RegExpMatch(&m, 1),
                                      current_Text()->baseFgColorId,
                                      none_ColorId,
                                      iFalse,
-                                     &clr,
+                                     &parsedColor,
                                      NULL,
                                      NULL);
+                    ansiFg = parsedColor;
+                    hasAnsi = iTrue;
+                    if (mode & draw_RunMode) {
 #if defined (LAGRANGE_ENABLE_STB_TRUETYPE)
-                    SDL_SetTextureColorMod(cache, clr.r, clr.g, clr.b);
+                        SDL_SetTextureColorMod(cache, parsedColor.r, parsedColor.g, parsedColor.b);
 #endif
 #if defined (SDL_SEAL_CURSES)
-                    SDL_SetRenderTextColor(render, clr.r, clr.g, clr.b);
+                        SDL_SetRenderTextColor(render, parsedColor.r, parsedColor.g, parsedColor.b);
 #endif
-                    if (args->mode & fillBackground_RunMode) {
-                        SDL_SetRenderDrawColor(render, clr.r, clr.g, clr.b, 0);
+                        if (args->mode & fillBackground_RunMode) {
+                            SDL_SetRenderDrawColor(render, parsedColor.r, parsedColor.g, parsedColor.b, 0);
+                        }
                     }
                 }
                 chPos = end_RegExpMatch(&m);
@@ -243,16 +249,20 @@ static void runSimple_Font_(iFont *d, const iRunArgs *args) {
                 else if (esc != 0x24) { /* ASCII Cancel */
                     colorNum = esc - asciiBase_ColorEscape;
                 }
-                if (mode & draw_RunMode && ~mode & permanentColorFlag_RunMode) {
+                if (mode & (draw_RunMode | measure_RunMode) && ~mode & permanentColorFlag_RunMode) {
                     const iColor clr = get_Color(colorNum);
+                    ansiFg = clr;
+                    hasAnsi = iTrue;
+                    if (mode & draw_RunMode) {
 #if defined (LAGRANGE_ENABLE_STB_TRUETYPE)
-                    SDL_SetTextureColorMod(cache, clr.r, clr.g, clr.b);
+                        SDL_SetTextureColorMod(cache, clr.r, clr.g, clr.b);
 #endif
 #if defined (SDL_SEAL_CURSES)
-                    SDL_SetRenderTextColor(render, clr.r, clr.g, clr.b);
+                        SDL_SetRenderTextColor(render, clr.r, clr.g, clr.b);
 #endif
-                    if (args->mode & fillBackground_RunMode) {
-                        SDL_SetRenderDrawColor(render, clr.r, clr.g, clr.b, 0);
+                        if (args->mode & fillBackground_RunMode) {
+                            SDL_SetRenderDrawColor(render, clr.r, clr.g, clr.b, 0);
+                        }
                     }
                 }
                 prevCh = 0;


### PR DESCRIPTION
when rendering wrapped text ANSI/ASCII color escapes were lost in soft line breaks cause state wasnt persistent across individual text like it was in #793 issue

so i changed tracking ansiFg color state and hasAnsi flag in runSimple_Font_ during both measure_RunMode and draw_RunMode and also ensure newly wrapped lines inherit the active color state from preceding escapes than back to the base color also i simplify drawWrapText_Text to route text wrapping directly through draw_WrapText